### PR TITLE
Update verifying_builds.md

### DIFF
--- a/pages/meta/verifying_builds.md
+++ b/pages/meta/verifying_builds.md
@@ -4,6 +4,17 @@ title: Verifying Build Authenticity
 folder: meta
 permalink: verifying-builds.html
 ---
+**CHANGE** The following is a new way, which replaced the *old* signature format in spring 2018
+
+```
+https://github.com/LineageOS/update_verifier.git
+cd update_verifier
+pip3 install -r requirements.txt
+python3 update_verifier.py lineageos_pubkey /path/to/zip
+```
+See: [source information] (https://github.com/LineageOS/update_verifier)
+
+#### *The old way*
 
 All official builds from LineageOS are signed with our private keys. You can verify a build has been signed with our keys by running: 
 


### PR DESCRIPTION
I have just learned, that the Lineage team has changed the way they sign the public builds.

I got to know why the **keytool** keep telling me: `Not a signed jar file` from this [post](https://forum.fairphone.com/t/official-lineageos-15-1-builds-not-signed/42173).

Please update your wiki page! :-)